### PR TITLE
Use git clean instead of rm -rf to avoid removing neccessary project files

### DIFF
--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -54,8 +54,10 @@ create_iotc_azrtos_symlinks() {
   target_dir=${2:-iotc-azrtos-sdk/}
 
   # Make sure that the script is idempotent
-  rm -rf $target_dir
   mkdir -p $target_dir
+  pushd $target_dir > /dev/null
+  git clean -Xdf;
+  popd > /dev/null
 
   pushd $target_dir >/dev/null
   for f in $source_dir/*; do


### PR DESCRIPTION
If we just blindly rm -rf target_dir (the sdk copy), then we delete all project files which need to stay there for same54xpro for example.