### PR TITLE
Extra setup script checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+srcdir            = ./iotc-azrtos-sdk/src
+CC_SOURCES        += $(wildcard $(srcdir)/*.c)
+srcdir1            = ./iotc-azrtos-sdk/azrtos-layer/src
+CC_SOURCES        += $(wildcard $(srcdir1)/*.c)
+srcdir2            = ./iotc-azrtos-sdk/azrtos-layer/azrtos-ota/src
+CC_SOURCES        += $(wildcard $(srcdir2)/*.c)
+srcdir3            = ./iotc-azrtos-sdk/azrtos-layer/nx-http-client
+CC_SOURCES        += $(wildcard $(srcdir3)/*.c)
+srcdir4            = ./samples/stm32l4/sensors-demo/src
+CC_SOURCES        += $(wildcard $(srcdir4)/*.c)
+srcdir5            = ./samples/stm32l4/sensors-demo/BSPv2/B-L475E-IOT01
+CC_SOURCES        += $(wildcard $(srcdir5)/*.c)
+srcdir6            = ./samples/stm32l4/sensors-demo/BSPv2/Components/lps22hb
+CC_SOURCES        += $(wildcard $(srcdir6)/*.c)
+srcdir7            = ./samples/stm32l4/sensors-demo/BSPv2/Components/lis3mdl
+CC_SOURCES        += $(wildcard $(srcdir7)/*.c)
+srcdir8            = ./samples/stm32l4/sensors-demo/BSPv2/Components/lsm6dsl
+CC_SOURCES        += $(wildcard $(srcdir8)/*.c)
+srcdir9            = ./samples/stm32l4/sensors-demo/BSPv2/Components/hts221
+CC_SOURCES        += $(wildcard $(srcdir9)/*.c)
+srcdir10            = ./samples/stm32l4/basic-sample/src
+CC_SOURCES        += $(wildcard $(srcdir10)/*.c)
+srcdir11            = ./samples/stm32l4/common_hardware_code
+CC_SOURCES        += $(wildcard $(srcdir11)/*.c)
+srcdir12            = ./samples/mimxrt1060/basic-sample/src
+CC_SOURCES        += $(wildcard $(srcdir12)/*.c)
+srcdir13            = ./samples/mimxrt1060/basic-sample/startup
+CC_SOURCES        += $(wildcard $(srcdir13)/*.c)
+srcdir14            = ./samples/mimxrt1060/basic-sample
+CC_SOURCES        += $(wildcard $(srcdir14)/*.c)
+srcdir15            = ./samples/maaxboardrt/basic-sample/xip
+CC_SOURCES        += $(wildcard $(srcdir15)/*.c)
+srcdir16            = ./samples/maaxboardrt/basic-sample/src
+CC_SOURCES        += $(wildcard $(srcdir16)/*.c)
+srcdir17            = ./samples/maaxboardrt/basic-sample/board
+CC_SOURCES        += $(wildcard $(srcdir17)/*.c)
+srcdir18            = ./samples/maaxboardrt/basic-sample/drivers
+CC_SOURCES        += $(wildcard $(srcdir18)/*.c)
+srcdir19            = ./samples/maaxboardrt/basic-sample/phy
+CC_SOURCES        += $(wildcard $(srcdir19)/*.c)
+srcdir20            = ./samples/nxpdemos/overlay/maaxboardrt/xip
+CC_SOURCES        += $(wildcard $(srcdir20)/*.c)
+srcdir21            = ./samples/nxpdemos/overlay/maaxboardrt/board
+CC_SOURCES        += $(wildcard $(srcdir21)/*.c)
+srcdir22            = ./samples/nxpdemos/overlay/maaxboardrt/iotconnectdemo
+CC_SOURCES        += $(wildcard $(srcdir22)/*.c)
+srcdir23            = ./samples/nxpdemos/overlay/maaxboardrt/phy
+CC_SOURCES        += $(wildcard $(srcdir23)/*.c)
+srcdir24            = ./samples/nxpdemos/overlay/lpc55s69/iotconnectdemo
+CC_SOURCES        += $(wildcard $(srcdir24)/*.c)
+srcdir25            = ./samples/nxpdemos/overlay/rt1060/iotconnectdemo
+CC_SOURCES        += $(wildcard $(srcdir25)/*.c)
+srcdir26            = ./samples/nxpdemos/iotconnectdemo
+CC_SOURCES        += $(wildcard $(srcdir26)/*.c)
+srcdir27            = ./samples/same54xpro/basic-sample/src
+CC_SOURCES        += $(wildcard $(srcdir27)/*.c)
+srcdir28            = ./samples/same54xpro/basic-sample
+CC_SOURCES        += $(wildcard $(srcdir28)/*.c)
+srcdir29            = ./samples/same54xpro/common_hardware_code
+CC_SOURCES        += $(wildcard $(srcdir29)/*.c)
+srcdir30	    = iotc-azrtos-sdk/authentication/driver/
+CC_SOURCES        += $(wildcard $(srcdir30)/*.c)
+srcdir31	    = samples/same54xprov2/basic-sample
+CC_SOURCES        += $(wildcard $(srcdir31)/*.c)
+srcdir32	    = samples/same54xprov2/src/azure_rtos_demo/
+CC_SOURCES        += $(wildcard $(srcdir32)/*.c)
+srcdir33	    = samples/same54xprov2/src/config/sam_e54_xpro/
+CC_SOURCES        += $(wildcard $(srcdir33)/*.c)
+
+CC_OBJS           = $(CC_SOURCES:%.c=%.o)
+CC ?= gcc
+INCLUDE_FLAGS += -Iiotc-azrtos-sdk/authentication/driver/ -Isamples/same54xprov2/basic-sample/include/ -I../libTO/Sources/include/ -I./iotc-azrtos-sdk/authentication/include/ -I./iotc-azrtos-sdk/authentication/driver/ -I../netxduo/addons/azure_iot/ -I../netxduo/nx_secure/ports -I../netxduo/nx_secure/inc/ -I../netxduo/crypto_libraries/inc/ -I../netxduo/common/inc -I../netxduo/ports/linux/gnu/inc/ -I../netxduo/addons/sntp/ -I../netxduo/addons/dns/ -I../netxduo/addons/dhcp/ -I../netx/common/inc/ -I../netx/ports/linux/gnu/inc/ -I../threadx/common/inc -I../threadx/ports/linux/gnu/inc/ -I../iotc-c-lib/include -I../iotc-generic-c-sdk/lib/cJSON -I./iotc-azrtos-sdk/azrtos-layer/azrtos-ota/include -I./iotc-azrtos-sdk/azrtos-layer/nx-http-client -I./iotc-azrtos-sdk/azrtos-layer/include -I./iotc-azrtos-sdk/include -I./samples/stm32l4/sensors-demo/src -I./samples/stm32l4/sensors-demo/BSPv2/Include -I./samples/stm32l4/sensors-demo/BSPv2/B-L475E-IOT01 -I./samples/stm32l4/sensors-demo/BSPv2/Components/lps22hb -I./samples/stm32l4/sensors-demo/BSPv2/Components/lis3mdl -I./samples/stm32l4/sensors-demo/BSPv2/Components/lsm6dsl -I./samples/stm32l4/sensors-demo/BSPv2/Components/Common -I./samples/stm32l4/sensors-demo/BSPv2/Components/hts221 -I./samples/stm32l4/sensors-demo/include -I./samples/stm32l4/basic-sample/src -I./samples/stm32l4/basic-sample/include -I./samples/mimxrt1060/basic-sample -I./samples/mimxrt1060/basic-sample/include -I./samples/maaxboardrt/basic-sample/board -I./samples/maaxboardrt/basic-sample/drivers -I./samples/maaxboardrt/basic-sample/include -I./samples/maaxboardrt/basic-sample/phy -I./samples/nxpdemos/overlay/maaxboardrt/board -I./samples/nxpdemos/overlay/maaxboardrt/phy -I./samples/nxpdemos/include -I./samples/same54xpro/basic-sample -I./samples/same54xpro/basic-sample/include -I./samples/same54xpro/common_hardware_code
+#CFLAGS += -O -g -Wall -Werror -Wextra -Wshadow -Werror=padded -pedantic
+CFLAGS += -O -g -Wall -Werror -Wextra -Wshadow -pedantic
+#CPPCHECK_FLAGS = --enable=all --force --inconclusive --library=posix
+CPPCHECK_FLAGS = --enable=all --force --inconclusive
+
+.PHONY: cppcheck
+
+all: $(CC_OBJS)
+
+.c.o: $(CC_SOURCES)
+	-$(CC) $(INCLUDE_FLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(CC_OBJS)
+
+cppcheck:
+	cppcheck $(CPPCHECK_FLAGS) $(INCLUDE_FLAGS) $(CC_SOURCES)
+
+clang-tidy:
+	clang-tidy $(CC_SOURCES)

--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -2,6 +2,27 @@
 
 set -e
 
+if [ $(uname -o | grep "Cygwin") ]; then
+  echo "Warning: this script does not support Cygwin. Please use WSL or 'git bash'."
+  exit -1;
+fi
+
+#
+# Select download mechanism given abilities of shells, etc.
+#
+which wget >& /dev/null
+if [ $? == 0 ]; then
+  FETCH="wget -q -O"
+else
+  which wget >& /dev/null
+  if [ $? == 0 ]; then
+    FETCH="curl -s --output"
+  else
+    echo "No wget or curl present"
+    exit -1;
+  fi
+fi
+
 show_help() {
   echo "Usage: $0 <project_name>"
   echo "Available projects: stm32l4, mimxrt1060, same54xpro, " \
@@ -83,9 +104,9 @@ create_iotc_azrtos_symlinks() {
 
 create_threadx_project_maxxboard() {
   echo Downloading MaaxXBoardRT baseline project packages...
-  wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_MIMXRT1060_MCUXpresso_Samples_2021_11_03.zip
+  ${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_MIMXRT1060_MCUXpresso_Samples_2021_11_03.zip
   azrtos_dir='mimxrt1060/MCUXpresso/'
-  wget -q -O project.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/evkmimxrt1170_azure_iot_embedded_sdk.zip
+  ${FETCH} project.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/evkmimxrt1170_azure_iot_embedded_sdk.zip
   project_dir=evkmimxrt1170_azure_iot_embedded_sdk/
 
   echo Extracting...
@@ -113,29 +134,29 @@ create_threadx_projects() {
   case "$name" in
     stm32l4)
       echo Downloading Azure_RTOS_6...
-      wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_STM32L4+-DISCO_STM32CubeIDE_Samples_2021_11_03.zip
+      ${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_STM32L4+-DISCO_STM32CubeIDE_Samples_2021_11_03.zip
       project_platform_dir='b-l4s5i-iot01a/'
       project_ide_dir='stm32cubeide/'
       libs="stm32l4xx_lib common_hardware_code "
       ;;
     mimxrt1060)
       echo Downloading Azure_RTOS_6...
-      wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_MIMXRT1060_MCUXpresso_Samples_2021_11_03.zip
+      ${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_MIMXRT1060_MCUXpresso_Samples_2021_11_03.zip
       project_platform_dir='mimxrt1060/'
       project_ide_dir='MCUXpresso/'
       libs="mimxrt1060_library filex common_hardware_code "
       ;;
     same54xpro)
       echo Downloading Azure_RTOS_6...
-      #wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_ATSAME54-XPRO_MPLab_Samples_2021_11_03.zip
-      wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_ADU_ATSAME54-XPRO_MPLab_Sample_2022_04_10.zip
+      #${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_ATSAME54-XPRO_MPLab_Samples_2021_11_03.zip
+      ${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_ADU_ATSAME54-XPRO_MPLab_Sample_2022_04_10.zip
       project_platform_dir='same54Xpro/'
       project_ide_dir='mplab/'
       libs="same54_lib filex common_hardware_code "
       ;;
     rx65ncloudkit)
       echo Downloading Azure_RTOS_6...
-      wget -q -O azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_RX65N_Cloud_Kit_E2Studio_GNURX_Samples_2022_05_25.zip
+      ${FETCH} azrtos.zip https://saleshosted.z13.web.core.windows.net/sdk/AzureRTOS/Azure_RTOS_6.1_RX65N_Cloud_Kit_E2Studio_GNURX_Samples_2022_05_25.zip
       project_platform_dir=''
       project_ide_dir='e2studio_gnurx/'
       libs="filex netxduo_addons "


### PR DESCRIPTION
Don't allow script to run under Cygwin -- symbolic linking doesn't work.

Allow Windows git bash shell to use curl, rather than wget.