### PR TITLE
Add more debug, and timeout on DHCP rather than silently waiting forever

### DIFF
--- a/samples/ck-rx65n/basic-sample/src/main.c
+++ b/samples/ck-rx65n/basic-sample/src/main.c
@@ -173,9 +173,9 @@ int main(void)
 void    tx_application_define(void *first_unused_memory)
 {
 
-	UINT  status;
+    UINT  status;
 
-	/* Initialize the demo printf implementation. */
+    /* Initialize the demo printf implementation. */
     demo_printf_init();
 
     /* Initialize the NetX system.  */
@@ -343,27 +343,52 @@ ULONG   gateway_address = 0;
 #ifndef SAMPLE_DHCP_DISABLE
 static void dhcp_wait()
 {
-ULONG   actual_status;
+    ULONG   actual_status;
+    int status;
 
     printf("DHCP In Progress...\r\n");
 
     /* Create the DHCP instance.  */
-    nx_dhcp_create(&dhcp_0, &ip_0, "DHCP Client");
+    status = nx_dhcp_create(&dhcp_0, &ip_0, "DHCP Client");
+    if(status != NX_SUCCESS) {
+        printf("nx_dhcp_create failed: %d\r\n", status);
+        return;
+    }
+    printf("nx_dhcp_create ok\r\n");
 
     /* Start the DHCP Client.  */
-    nx_dhcp_start(&dhcp_0);
+    status = nx_dhcp_start(&dhcp_0);
+    if(status != NX_SUCCESS) {
+        printf("nx_dhcp_start failed: %d\r\n", status);
+        return;
+    }
+    printf("nx_dhcp_start ok\r\n");
 
-    /* Wait util address is solved. */
-    nx_ip_status_check(&ip_0, NX_IP_ADDRESS_RESOLVED, &actual_status, NX_WAIT_FOREVER);
+    /* Wait until address is resolved, or times out. */
+    status = nx_ip_status_check(&ip_0, NX_IP_ADDRESS_RESOLVED, &actual_status, 1000);
+    for(int i = 0; i < 10 && status != NX_SUCCESS;i++)
+    {
+        tx_thread_sleep(NX_IP_PERIODIC_RATE * 10);
+	
+        printf("retry nx_ip_status_check %d\r\n", i);
+        status = nx_ip_status_check(&ip_0, NX_IP_ADDRESS_RESOLVED, &actual_status, 1000);
+    }
+    if(status != NX_SUCCESS)
+    {
+        printf("nx_ip_status_check failed: %d\r\n", status);
+        return;
+    }
+    printf("nx_ip_status_check ok\r\n");
+    printf("...DHCP Finished\r\n");
 }
 #endif /* SAMPLE_DHCP_DISABLE  */
 
 static UINT dns_create()
 {
 
-UINT    status;
-ULONG   dns_server_address[3];
-UINT    dns_server_address_size = 12;
+    UINT    status;
+    ULONG   dns_server_address[3]; // IPv6 needs more than one ULONG
+    UINT    dns_server_address_size = sizeof(dns_server_address);
 
     /* Create a DNS instance for the Client.  Note this function will create
        the DNS Client packet pool for creating DNS message packets intended
@@ -371,6 +396,7 @@ UINT    dns_server_address_size = 12;
     status = nx_dns_create(&dns_0, &ip_0, (UCHAR *)"DNS Client");
     if (status)
     {
+        printf("nx_dns_create failed: status = %d\r\n", status);
         return(status);
     }
 
@@ -382,6 +408,7 @@ UINT    dns_server_address_size = 12;
     status = nx_dns_packet_pool_set(&dns_0, ip_0.nx_ip_default_packet_pool);
     if (status)
     {
+        printf("nx_dns_packet_pool_set failed: status = %d\r\n", status);
         nx_dns_delete(&dns_0);
         return(status);
     }
@@ -389,8 +416,14 @@ UINT    dns_server_address_size = 12;
 
 #ifndef SAMPLE_DHCP_DISABLE
     /* Retrieve DNS server address.  */
-    nx_dhcp_interface_user_option_retrieve(&dhcp_0, 0, NX_DHCP_OPTION_DNS_SVR, (UCHAR *)(dns_server_address),
+    status = nx_dhcp_interface_user_option_retrieve(&dhcp_0, 0, NX_DHCP_OPTION_DNS_SVR, (UCHAR *)(dns_server_address),
                                            &dns_server_address_size);
+    if (status)
+    {
+        printf("nx_dhcp_interface_user_option_retrieve failed: status = %d\r\n", status);
+        nx_dns_delete(&dns_0);
+        return(status);
+    }
 #else
     dns_server_address[0] = SAMPLE_DNS_SERVER_ADDRESS;
 #endif /* SAMPLE_DHCP_DISABLE */
@@ -399,6 +432,7 @@ UINT    dns_server_address_size = 12;
     status = nx_dns_server_add(&dns_0, dns_server_address[0]);
     if (status)
     {
+        printf("nx_dns_server_add failed: status = %d\r\n", status);
         nx_dns_delete(&dns_0);
         return(status);
     }
@@ -412,7 +446,3 @@ UINT    dns_server_address_size = 12;
 
     return(NX_SUCCESS);
 }
-
-
-
-


### PR DESCRIPTION
Split DHCP timeout into sections and add a delay.

The debug is helpful to track progress -- having a timeout is also useful -- rather than waiting indefinitely without any output (if there's a problem).

Not sure whether splitting the timeout into sections is necessary -- but it should give other threads a chance to update themselves and maybe IP related values, too.