### PR TITLE
Project fixes for compile errors caused by project restructuring

### DIFF
--- a/samples/maaxboardrt/basic-sample/.cproject
+++ b/samples/maaxboardrt/basic-sample/.cproject
@@ -461,16 +461,6 @@
 							<tool id="com.crt.advproject.tool.debug.debug.2072828259" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.debug.1148952252"/>
 						</toolChain>
 					</folderInfo>
-					<folderInfo id="com.crt.advproject.config.exe.debug.282996926.31565871" name="/" resourcePath="iotc-azrtos-sdk/iotc-c-lib">
-						<toolChain id="com.crt.advproject.toolchain.exe.debug.1003419351" name="NXP MCU Tools" superClass="com.crt.advproject.toolchain.exe.debug" unusedChildren="">
-							<tool id="com.crt.advproject.cpp.exe.debug.733453102" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug.371687061"/>
-							<tool id="com.crt.advproject.gcc.exe.debug.444237350" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.1290402586"/>
-							<tool id="com.crt.advproject.gas.exe.debug.1257573140" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.debug.85050012"/>
-							<tool id="com.crt.advproject.link.cpp.exe.debug.10123563" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.debug.14811107"/>
-							<tool id="com.crt.advproject.link.exe.debug.889905" name="MCU Linker" superClass="com.crt.advproject.link.exe.debug.2078035709"/>
-							<tool id="com.crt.advproject.tool.debug.debug.26986413" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.debug.2072828259"/>
-						</toolChain>
-					</folderInfo>
 					<sourceEntries>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
 						<entry excluding="netxduo/addons/azure_iot/azure_iot_security_module/nx_azure_iot_security_module.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/collector_collection_internal.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_json_token.c|netxduo/addons/azure_iot/azure_iot_security_module/src/model/objects/object_network_activity_ext.c|netxduo/addons/azure_iot/azure_iot_security_module/src/collectors/collector_network_activity.c|netxduo/addons/azure_iot/azure_iot_security_module/src/utils/irand.c|netxduo/addons/azure_iot/nx_azure_iot.c|netxduo/addons/azure_iot/azure_iot_security_module/src/utils/iuuid.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/heartbeat.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/system_information.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/utils/notifier.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/utils/string_utils.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/extensions/page_allocator.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client_c2d.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/extensions/custom_builder_allocator.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_response.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_provisioning_client.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/model/collector.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/collector_collection.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/serializer.c|netxduo/addons/azure_iot/nx_azure_iot_json_writer.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_policy_retry.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client_twin.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/model/security_message.c|netxduo/addons/azure_iot/nx_azure_iot_json_reader.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client_telemetry.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_log.c|netxduo/addons/azure_iot/nx_azure_iot_hub_client.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_span.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/network_activity.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/serializer_private.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_policy.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/platform/az_noplatform.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_pipeline.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/collector_collection_factory.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/core.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/serializer/extensions/custom_emitter.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/deps/flatcc/src/runtime/refmap.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_json_writer.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/collectors/collector_heartbeat.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_common.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_json_reader.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/deps/flatcc/src/runtime/builder.c|netxduo/addons/azure_iot/azure_iot_security_module/src/collectors/collector_system_information.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_provisioning_client_sas.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_precondition.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/utils/event_loop_be.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_context.c|netxduo/addons/azure_iot/azure_iot_security_module/src/utils/itime.c|netxduo/addons/azure_iot/azure_iot_security_module/src/utils/os_utils.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client_sas.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/collectors_info.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_policy_logging.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/iot/az_iot_hub_client_methods.c|netxduo/addons/azure_iot/nx_azure_iot_provisioning_client.c|netxduo/addons/azure_iot/azure_iot_security_module/iot-security-module-core/src/logger.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/platform/az_nohttp.c|netxduo/addons/azure_iot/azure-sdk-for-c/sdk/src/azure/core/az_http_request.c" flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="azure-rtos"/>
@@ -478,7 +468,7 @@
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="component"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
-						<entry excluding="libTO/src/wrapper|libTO/examples|azrtos-layer/nx-http-client" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="iotc-azrtos-sdk"/>
+						<entry excluding="azrtos-layer/azrtos-ota/src/azrtos_ota_fw_client.c|libTO/src/wrapper|libTO/examples|azrtos-layer/nx-http-client" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="iotc-azrtos-sdk"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="mdio"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="phy"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ports"/>
@@ -1048,7 +1038,7 @@
 	<storageModule moduleId="com.nxp.mcuxpresso.core.datamodels">
 		<sdkName>SDK_2.x_MIMXRT1170-EVK</sdkName>
 		<sdkExample>evkmimxrt1170_azure_iot_embedded_sdk</sdkExample>
-		<sdkVersion>2.11.1</sdkVersion>
+		<sdkVersion>2.12.1</sdkVersion>
 		<sdkComponents>middleware.azure_rtos.azure_iot.MIMXRT1176;middleware.azure_rtos.nxd.MIMXRT1176;driver.mdio-enet.MIMXRT1176;driver.phy-device-ksz8081.MIMXRT1176;driver.phy-device-rtl8211f.MIMXRT1176;platform.drivers.caam.MIMXRT1176;component.lists.MIMXRT1176;component.lpuart_adapter.MIMXRT1176;component.serial_manager.MIMXRT1176;platform.drivers.common.MIMXRT1176;component.serial_manager_uart.MIMXRT1176;platform.drivers.lpuart.MIMXRT1176;platform.devices.MIMXRT1176_CMSIS.MIMXRT1176;platform.devices.MIMXRT1176_startup.MIMXRT1176;platform.drivers.cache_armv7_m7.MIMXRT1176;platform.drivers.clock.MIMXRT1176;platform.drivers.dcdc_soc.MIMXRT1176;platform.drivers.igpio.MIMXRT1176;platform.drivers.iomuxc.MIMXRT1176;platform.drivers.lpi2c.MIMXRT1176;platform.drivers.pmu_1.MIMXRT1176;platform.drivers.xip_board.evkmimxrt1170.MIMXRT1176;platform.drivers.xip_device.MIMXRT1176;platform.utilities.assert.MIMXRT1176;utility.debug_console.MIMXRT1176;middleware.azure_rtos.nxd.template.MIMXRT1176;middleware.azure_rtos.fx.MIMXRT1176;middleware.azure_rtos.fx.template.MIMXRT1176;middleware.azure_rtos.tx.MIMXRT1176;middleware.azure_rtos.tx.template.MIMXRT1176;driver.mdio-common.MIMXRT1176;platform.drivers.anatop_ai.MIMXRT1176;CMSIS_Include_core_cm.MIMXRT1176;platform.drivers.enet.MIMXRT1176;platform.drivers.memory.MIMXRT1176;driver.phy-common.MIMXRT1176;platform.utilities.misc_utilities.MIMXRT1176;platform.devices.MIMXRT1176_system.MIMXRT1176;evkmimxrt1170_azure_iot_embedded_sdk;</sdkComponents>
 		<boardId>evkmimxrt1170</boardId>
 		<package>MIMXRT1176DVMAA</package>
@@ -1056,37 +1046,37 @@
 		<coreId>cm7_MIMXRT1176xxxxx</coreId>
 	</storageModule>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1176xxxxx" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1176xxxxx" name="MIMXRT1176xxxxx"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1176xxxxx&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1170&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="2048" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="Flash" driver="${workspace_loc:}/samples/maaxboardrt/basic-sample/xip/MaaXBoard_S26KS256.cfx" edited="true" id="BOARD_FLASH" location="0x30000000" size="0x1000000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC_cm7" location="0x20000000" size="0x40000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC_cm7" location="0x0" size="0x40000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC1" location="0x20240000" size="0x80000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC2" location="0x202c0000" size="0x40000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="NCACHE_REGION" location="0x20300000" size="0x40000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC1" location="0x20340000" size="0x10000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC2" location="0x20350000" size="0x10000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x4000000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1176xxxxx" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1176xxxxx" name="MIMXRT1176xxxxx"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1176xxxxx&lt;/name&gt;
+&lt;family&gt;MIMXRT1170&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="2048" type="RAM"/&gt;
+&lt;memoryInstance derived_from="Flash" driver="${workspace_loc:}/samples/maaxboardrt/basic-sample/xip/MaaXBoard_S26KS256.cfx" edited="true" id="BOARD_FLASH" location="0x30000000" size="0x1000000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC_cm7" location="0x20000000" size="0x40000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC_cm7" location="0x0" size="0x40000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC1" location="0x20240000" size="0x80000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC2" location="0x202c0000" size="0x40000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="NCACHE_REGION" location="0x20300000" size="0x40000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC1" location="0x20340000" size="0x10000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC_ECC2" location="0x20350000" size="0x10000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x4000000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m4"&gt;Cortex-M4&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/maaxboardrt/basic-sample/src/iotconnect_app.c
+++ b/samples/maaxboardrt/basic-sample/src/iotconnect_app.c
@@ -159,7 +159,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/maaxboardrt/netxduo/.cproject
+++ b/samples/maaxboardrt/netxduo/.cproject
@@ -81,7 +81,6 @@
 									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
 									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
 									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
-									<listOptionValue builtIn="false" value="PRINTF_ADVANCED_ENABLE=1"/>
 									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
 									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
 									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
@@ -387,27 +386,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
@@ -421,7 +420,7 @@
 	</storageModule>
 	<storageModule moduleId="com.nxp.mcuxpresso.core.datamodels">
 		<sdkName>SDK_2.x_EVK-MIMXRT1060</sdkName>
-		<sdkVersion>2.10.1</sdkVersion>
+		<sdkVersion>2.12.0</sdkVersion>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>

--- a/samples/mimxrt1060/basic-sample/.cproject
+++ b/samples/mimxrt1060/basic-sample/.cproject
@@ -635,30 +635,30 @@
 		<coreId>core0_MIMXRT1062xxxxA</coreId>
 	</storageModule>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="Flash" driver="MIMXRT1060_SFDP_QSPI.cfx" edited="true" id="BOARD_FLASH" location="0x60002000" size="0x800000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0xc0000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x1e00000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="NC_RAM" location="0x81e00000" size="0x200000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="Flash" driver="MIMXRT1060_SFDP_QSPI.cfx" edited="true" id="BOARD_FLASH" location="0x60002000" size="0x800000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0xc0000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="BOARD_SDRAM" location="0x80000000" size="0x1e00000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="NC_RAM" location="0x81e00000" size="0x200000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="refreshScope" versionNumber="2">

--- a/samples/mimxrt1060/basic-sample/src/iotconnect_app.c
+++ b/samples/mimxrt1060/basic-sample/src/iotconnect_app.c
@@ -159,7 +159,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/mimxrt1060/filex/.cproject
+++ b/samples/mimxrt1060/filex/.cproject
@@ -339,27 +339,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/mimxrt1060/iotc-azrtos-sdk/.cproject
+++ b/samples/mimxrt1060/iotc-azrtos-sdk/.cproject
@@ -159,7 +159,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="azrtos-layer/azrtos-ota/src/azrtos_ota_fw_client.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -362,27 +362,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/mimxrt1060/mimxrt1060_library/.cproject
+++ b/samples/mimxrt1060/mimxrt1060_library/.cproject
@@ -343,27 +343,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/mimxrt1060/netxduo/.cproject
+++ b/samples/mimxrt1060/netxduo/.cproject
@@ -6,10 +6,7 @@
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/netxduo"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/netxduo"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/netxduo/Debug"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/netxduo/Debug"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="netxduo" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="netxduo" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -78,7 +75,6 @@
 									<listOptionValue builtIn="false" value="SDK_DEBUGCONSOLE=1"/>
 									<listOptionValue builtIn="false" value="XIP_EXTERNAL_FLASH=1"/>
 									<listOptionValue builtIn="false" value="XIP_BOOT_HEADER_ENABLE=1"/>
-									<listOptionValue builtIn="false" value="PRINTF_ADVANCED_ENABLE=1"/>
 									<listOptionValue builtIn="false" value="CR_INTEGER_PRINTF"/>
 									<listOptionValue builtIn="false" value="PRINTF_FLOAT_ENABLE=0"/>
 									<listOptionValue builtIn="false" value="__MCUXPRESSO"/>
@@ -204,10 +200,7 @@
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/netxduo"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/netxduo"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/netxduo/Release"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/netxduo/Release"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="netxduo" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="netxduo" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -388,27 +381,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/mimxrt1060/threadx/.cproject
+++ b/samples/mimxrt1060/threadx/.cproject
@@ -6,10 +6,7 @@
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/threadx"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/threadx"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/threadx/Debug"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/threadx/Debug"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="threadx" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="threadx" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -150,10 +147,7 @@
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/threadx"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/threadx"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/threadx/Release"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/threadx/Release"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="threadx" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="threadx" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -326,27 +320,27 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="com.crt.config">
-		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
-&lt;TargetConfig&gt;&#13;
-&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;&#13;
-&lt;family&gt;MIMXRT1060&lt;/family&gt;&#13;
-&lt;vendor&gt;NXP&lt;/vendor&gt;&#13;
-&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;&#13;
-&lt;memory id="RAM" size="1024" type="RAM"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;&#13;
-&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;&#13;
-&lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;&#13;
-&lt;family&gt;Cortex-M&lt;/family&gt;&#13;
-&lt;/processor&gt;&#13;
-&lt;/info&gt;&#13;
-&lt;/infoList&gt;&#13;
+		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;TargetConfig&gt;
+&lt;Properties property_3="NXP" property_4="MIMXRT1062xxxxA" property_count="5" version="100300"/&gt;
+&lt;infoList vendor="NXP"&gt;
+&lt;info chip="MIMXRT1062xxxxA" name="MIMXRT1062xxxxA"&gt;
+&lt;chip&gt;
+&lt;name&gt;MIMXRT1062xxxxA&lt;/name&gt;
+&lt;family&gt;MIMXRT1060&lt;/family&gt;
+&lt;vendor&gt;NXP&lt;/vendor&gt;
+&lt;memory can_program="true" id="Flash" is_ro="true" size="0" type="Flash"/&gt;
+&lt;memory id="RAM" size="1024" type="RAM"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_DTC" location="0x20000000" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_ITC" location="0x0" size="0x20000"/&gt;
+&lt;memoryInstance derived_from="RAM" edited="true" id="SRAM_OC" location="0x20200000" size="0x40000"/&gt;
+&lt;/chip&gt;
+&lt;processor&gt;
+&lt;name gcc_name="cortex-m7"&gt;Cortex-M7&lt;/name&gt;
+&lt;family&gt;Cortex-M&lt;/family&gt;
+&lt;/processor&gt;
+&lt;/info&gt;
+&lt;/infoList&gt;
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>

--- a/samples/same54xpro/basic-sample/src/iotconnect_app.c
+++ b/samples/same54xpro/basic-sample/src/iotconnect_app.c
@@ -265,7 +265,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/same54xpro/iotc-azrtos-sdk/nbproject/configurations.xml
+++ b/samples/same54xpro/iotc-azrtos-sdk/nbproject/configurations.xml
@@ -24,7 +24,6 @@
                      projectFiles="true">
         <logicalFolder name="azrtos-adu" displayName="azrtos-adu" projectFiles="true">
           <logicalFolder name="include" displayName="include" projectFiles="true">
-            <itemPath>azrtos-layer/azrtos-adu/include/azrtos_adu_agent.h</itemPath>
           </logicalFolder>
           <logicalFolder name="src" displayName="src" projectFiles="true">
           </logicalFolder>

--- a/samples/same54xprov2/basic-sample/src/iotconnect_app.c
+++ b/samples/same54xprov2/basic-sample/src/iotconnect_app.c
@@ -159,7 +159,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/same54xprov2/iotconnect-demo.X/nbproject/configurations.xml
+++ b/samples/same54xprov2/iotconnect-demo.X/nbproject/configurations.xml
@@ -933,109 +933,6 @@
           <itemPath>../iotc-azrtos-sdk/iotc-c-lib/src/iotconnect_common.c</itemPath>
         </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="libTO" displayName="libTO" projectFiles="true">
-        <logicalFolder name="include" displayName="include" projectFiles="true">
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_SSE_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_measured_boot.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_lora.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_legacy.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_encrypt.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_helper_certs.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_loader.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP_vt.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_defs.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_tls.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_seclink.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_admin.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_i2c.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_helper_measured_boot.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_sha256.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_misc.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_stdint.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_loader.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_lora.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_endian.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_setup.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_secmsg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_statuspio.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_SSE.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_hash.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_i2c_wrapper.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP_storage.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_log.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_defs.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_helper.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP_SecureStorage.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_mac.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_auth.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_retcodes.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_measure.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_system.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_helper_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_hashes.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_helper_tls.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_tls.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_keys.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_keys.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_cmd.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_system.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_cfg.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOH_log.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_utils.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_admin.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_encryption.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_nvm.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOP_info.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_auth.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_driver.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_core.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TO_aes-gcm-sw.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TOSE_mac.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/include/TODRV_HSE_nvm.h</itemPath>
-        </logicalFolder>
-        <logicalFolder name="src" displayName="src" projectFiles="true">
-          <logicalFolder name="aes-gcm-sw" displayName="aes-gcm-sw" projectFiles="true">
-            <itemPath>../iotc-azrtos-sdk/libTO/src/aes-gcm-sw/TO_aes.h</itemPath>
-            <itemPath>../iotc-azrtos-sdk/libTO/src/aes-gcm-sw/aes-gcm-sw.c</itemPath>
-            <itemPath>../iotc-azrtos-sdk/libTO/src/aes-gcm-sw/aes.c</itemPath>
-            <itemPath>../iotc-azrtos-sdk/libTO/src/aes-gcm-sw/TO_gcm.h</itemPath>
-            <itemPath>../iotc-azrtos-sdk/libTO/src/aes-gcm-sw/gcm.c</itemPath>
-          </logicalFolder>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_mac.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_hash.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/seclink.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/helper_certs.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_auth.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_core.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/sha256.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/helper_measured_boot.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_encrypt.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/seclink_none.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_lora.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_tls.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/sse_driver.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/log.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/sse_driver.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/seclink.h</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_loader.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/utils.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_keys.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/hse_driver.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/helper_tls.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_nvm.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_system.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_admin.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/selftest.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/api_measure.c</itemPath>
-          <itemPath>../iotc-azrtos-sdk/libTO/src/driver_client.c</itemPath>
-        </logicalFolder>
-      </logicalFolder>
       <logicalFolder name="src" displayName="src" projectFiles="true">
         <itemPath>../iotc-azrtos-sdk/src/iotconnect_di.c</itemPath>
         <itemPath>../iotc-azrtos-sdk/src/iotconnect.c</itemPath>
@@ -2995,6 +2892,14 @@
         <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
         <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
       </makeCustomizationType>
+      <item path="../iotc-azrtos-sdk/authentication/driver/to_auth_driver.c"
+            ex="true"
+            overriding="false">
+      </item>
+      <item path="../iotc-azrtos-sdk/azrtos-layer/azrtos-ota/src/azrtos_ota_fw_client.c"
+            ex="true"
+            overriding="false">
+      </item>
       <item path="../src/azure_rtos_demo/sample_azure_iot_embedded_sdk/nx_azure_iot_ciphersuites.c"
             ex="true"
             overriding="false">
@@ -3265,6 +3170,8 @@
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-fffff"/>
         <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmerToGoFilePath"
+                  value="/avnet/iotc-azurertos-sdk-stmtest/samples/same54xprov2/iotconnect-demo.X/debug/sam_e54_xpro/iotconnect-demo_ptg"/>
         <property key="programoptions.eraseb4program" value="true"/>
         <property key="programoptions.preservedataflash" value="false"/>
         <property key="programoptions.preservedataflash.ranges"

--- a/samples/stm32l4/basic-sample/.cproject
+++ b/samples/stm32l4/basic-sample/.cproject
@@ -70,6 +70,7 @@
 									<listOptionValue builtIn="false" value="../../netxduo/addons/mqtt"/>
 									<listOptionValue builtIn="false" value="../../netxduo/addons/cloud"/>
 									<listOptionValue builtIn="false" value="../../netxduo/addons/sntp"/>
+									<listOptionValue builtIn="false" value="../../netxduo/common/azure_iot"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib/CMSIS/Device/ST/STM32L4xx/Include"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib/CMSIS/Include"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib"/>
@@ -79,7 +80,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/iotc-c-lib/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/netxduo/addons/azure_iot}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/azrtos-ota/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/netxduo/addons/azure_iot/azure-sdk-for-c/sdk/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/nx-http-client}&quot;"/>

--- a/samples/stm32l4/basic-sample/src/iotconnect_app.c
+++ b/samples/stm32l4/basic-sample/src/iotconnect_app.c
@@ -280,7 +280,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/stm32l4/iotc-azrtos-sdk/.cproject
+++ b/samples/stm32l4/iotc-azrtos-sdk/.cproject
@@ -108,7 +108,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="libTO/examples|libTO/src/wrapper|authentication/libto/examples|authentication/libto/src/aes-gcm-sw|authentication/libto/src/wrapper|hardware/libto/src/aes-gcm-sw|hardware/libto/doc|hardware/libto/examples|hardware/libto/src/wrapper" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="iotc-c-lib/tools|iotc-c-lib/tests|libTO/examples|libTO/src/wrapper|authentication/libto/examples|authentication/libto/src/aes-gcm-sw|authentication/libto/src/wrapper|hardware/libto/src/aes-gcm-sw|hardware/libto/doc|hardware/libto/examples|hardware/libto/src/wrapper" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -215,7 +215,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="libTO/examples|libTO/src/wrapper|authentication/libto/examples|authentication/libto/src/aes-gcm-sw|authentication/libto/src/wrapper|hardware/libto/src/aes-gcm-sw|hardware/libto/doc|hardware/libto/examples|hardware/libto/src/wrapper" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="iotc-c-lib/tools|iotc-c-lib/tests|libTO/examples|libTO/src/wrapper|authentication/libto/examples|authentication/libto/src/aes-gcm-sw|authentication/libto/src/wrapper|hardware/libto/src/aes-gcm-sw|hardware/libto/doc|hardware/libto/examples|hardware/libto/src/wrapper" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/samples/stm32l4/sensors-demo/.cproject
+++ b/samples/stm32l4/sensors-demo/.cproject
@@ -70,6 +70,8 @@
 									<listOptionValue builtIn="false" value="../../netxduo/addons/mqtt"/>
 									<listOptionValue builtIn="false" value="../../netxduo/addons/cloud"/>
 									<listOptionValue builtIn="false" value="../../netxduo/addons/sntp"/>
+									<listOptionValue builtIn="false" value="../../netxduo/addons/azure_iot"/>
+									<listOptionValue builtIn="false" value="../../netxduo/common/azure_iot"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib/CMSIS/Device/ST/STM32L4xx/Include"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib/CMSIS/Include"/>
 									<listOptionValue builtIn="false" value="../../stm32l4xx_lib"/>
@@ -79,6 +81,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/azrtos-ota/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/azrtos-adu/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/netxduo/addons/azure_iot}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/netxduo/addons/azure_iot/azure-sdk-for-c/sdk/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/iotc-azrtos-sdk/azrtos-layer/nx-http-client}&quot;"/>

--- a/samples/stm32l4/sensors-demo/src/iotconnect_app.c
+++ b/samples/stm32l4/sensors-demo/src/iotconnect_app.c
@@ -269,7 +269,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.

--- a/samples/stm32l4/sensors-demo/src/main.c
+++ b/samples/stm32l4/sensors-demo/src/main.c
@@ -26,7 +26,6 @@
 
 extern bool app_startup(NX_IP *ip_ptr, NX_PACKET_POOL *pool_ptr, NX_DNS *dns_ptr);
 extern CHAR* http_entry(NX_IP *ip_ptr, NX_PACKET_POOL *pool_ptr, NX_DNS *dns_ptr, CHAR *host_name, CHAR *resource);
-static void sample_thread_entry(ULONG parameter);
 // -----------------------------
 
 /* Define the helper thread for running Azure SDK on ThreadX (THREADX IoT Platform).  */

--- a/samples/stm32u5/Projects/B-U585I-IOT02A/Applications/NetXDuo/Nx_Azure_IoT/STM32CubeIDE/.cproject
+++ b/samples/stm32u5/Projects/B-U585I-IOT02A/Applications/NetXDuo/Nx_Azure_IoT/STM32CubeIDE/.cproject
@@ -150,7 +150,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="iotc-azrtos-sdk/azrtos-layer/nx-http-client/nx_web_http_client.c|Application/User/NetXDuo/Addons_IoT/nx_azure_iot_ciphersuites.c|iotc-azrtos-sdk/authentication/driver/to_auth_driver.c|iotc-azrtos-sdk/cJSON/test.c|iotc-azrtos-sdk/cJSON/cJSON_Utils.c|iotc-azrtos-sdk/iotc-c-lib/tools|iotc-azrtos-sdk/iotc-c-lib/tests|iotc-azrtos-sdk/libTO|Middlewares/Interfaces/Network/wifi/nx_driver_emw3080.c|Middlewares/Interfaces/Network/cellular/nx_driver_stm32_cellular.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="iotc-azrtos-sdk/azrtos-layer/azrtos-ota/src/azrtos_ota_fw_client.c|iotc-azrtos-sdk/azrtos-layer/nx-http-client/nx_web_http_client.c|Application/User/NetXDuo/Addons_IoT/nx_azure_iot_ciphersuites.c|iotc-azrtos-sdk/authentication/driver/to_auth_driver.c|iotc-azrtos-sdk/cJSON/test.c|iotc-azrtos-sdk/cJSON/cJSON_Utils.c|iotc-azrtos-sdk/iotc-c-lib/tools|iotc-azrtos-sdk/iotc-c-lib/tests|iotc-azrtos-sdk/libTO|Middlewares/Interfaces/Network/wifi/nx_driver_emw3080.c|Middlewares/Interfaces/Network/cellular/nx_driver_stm32_cellular.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -300,7 +300,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="iotc-azrtos-sdk/azrtos-layer/nx-http-client/nx_web_http_client.c|Application/User/NetXDuo/Addons_IoT/nx_azure_iot_ciphersuites.c|iotc-azrtos-sdk/authentication/driver/to_auth_driver.c|iotc-azrtos-sdk/cJSON/test.c|iotc-azrtos-sdk/cJSON/cJSON_Utils.c|iotc-azrtos-sdk/iotc-c-lib/tools|iotc-azrtos-sdk/iotc-c-lib/tests|iotc-azrtos-sdk/libTO|Middlewares/Interfaces/Network/wifi/nx_driver_emw3080.c|Middlewares/Interfaces/Network/cellular/nx_driver_stm32_cellular.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="iotc-azrtos-sdk/azrtos-layer/azrtos-ota/src/azrtos_ota_fw_client.c|iotc-azrtos-sdk/azrtos-layer/nx-http-client/nx_web_http_client.c|Application/User/NetXDuo/Addons_IoT/nx_azure_iot_ciphersuites.c|iotc-azrtos-sdk/authentication/driver/to_auth_driver.c|iotc-azrtos-sdk/cJSON/test.c|iotc-azrtos-sdk/cJSON/cJSON_Utils.c|iotc-azrtos-sdk/iotc-c-lib/tools|iotc-azrtos-sdk/iotc-c-lib/tests|iotc-azrtos-sdk/libTO|Middlewares/Interfaces/Network/wifi/nx_driver_emw3080.c|Middlewares/Interfaces/Network/cellular/nx_driver_stm32_cellular.c" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/samples/stm32u5/basic-sample/src/iotconnect_app.c
+++ b/samples/stm32u5/basic-sample/src/iotconnect_app.c
@@ -168,7 +168,7 @@ static void on_connection_status(IotConnectConnectionStatus status) {
 }
 
 static void publish_telemetry() {
-    IotclMessageHandle msg = iotcl_telemetry_create(iotconnect_sdk_get_lib_config());
+    IotclMessageHandle msg = iotcl_telemetry_create();
 
     // Optional. The first time you create a data point, the current timestamp will be automatically added
     // TelemetryAddWith* calls are only required if sending multiple data points in one packet.


### PR DESCRIPTION
One or more of the earlier updates caused problems with missing header files and iotc-c-lib related issues.

This PR fixes those.